### PR TITLE
Change version output to work with -v command line argument

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -3,8 +3,8 @@
 function getMMDVMHostVersion() {
 	// returns creation-time of MMDVMHost as version-number
 	$filename = MMDVMHOSTPATH . "MMDVMHost";
-	exec($filename." 2>&1", $output);
-	return substr($output[1],10,8)." (compiled ".getMMDVMHostFileVersion().")";
+	exec($filename." -v 2>&1", $output);
+	return substr($output[0],18,8)." (compiled ".getMMDVMHostFileVersion().")";
 }
 
 function getMMDVMHostFileVersion() {


### PR DESCRIPTION
Pull Request #70 on MMDVMHost

To be honest, thinking about it, I don't think you need the 2>&1 now as I coded the version output to be printed to STDERR - one for you to test ;-)
