### PR TITLE
Correct display of QRG

### DIFF
--- a/include/tools.php
+++ b/include/tools.php
@@ -30,7 +30,7 @@ function startsWith($haystack, $needle) {
 }
 
 function getMHZ($freq) {
-	return substr($freq,0,3) . "." . substr($freq,3,3) . "." . substr($freq,6) . " Mhz";
+	return substr($freq,0,3) . "." . substr($freq,3,6) . " MHz";
 }
 
 function isProcessRunning($processname) {


### PR DESCRIPTION
The current display is a bit confusing. It is actually displaying kHz but says Mhz. I suggest that a dot is used as a decimal separator (English) and the second one is omitted.
