### PR TITLE
Only initialize YSF infos if YSFGateway is enabled

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -499,8 +499,10 @@ $logLinesMMDVM = getMMDVMLog();
 $reverseLogLinesMMDVM = $logLinesMMDVM;
 array_multisort($reverseLogLinesMMDVM,SORT_DESC);
 $lastHeard = getLastHeard($reverseLogLinesMMDVM);
-$YSFGatewayconfigs = getYSFGatewayConfig();
-$logLinesYSFGateway = getYSFGatewayLog();
-$reverseLogLinesYSFGateway = $logLinesYSFGateway;
-array_multisort($reverseLogLinesYSFGateway,SORT_DESC);
+if (defined("ENABLEYSFGATEWAY")) {
+	$YSFGatewayconfigs = getYSFGatewayConfig();
+	$logLinesYSFGateway = getYSFGatewayLog();
+	$reverseLogLinesYSFGateway = $logLinesYSFGateway;
+	array_multisort($reverseLogLinesYSFGateway,SORT_DESC);
+}
 ?>


### PR DESCRIPTION
Prevent error messages in web server logs if YSFGateway is disabled.
