### PR TITLE
Handle log lines for lost RF transmissions correctly

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -240,7 +240,7 @@ function getHeardList($logLines, $onlyLast) {
 			continue;
 		}
 
-		if(strpos($logLine,"end of") || strpos($logLine,"watchdog has expired") || strpos($logLine,"ended RF data") || strpos($logLine,"ended network") || strpos($logLine,"RF transmission lost")) {
+		if(strpos($logLine,"end of") || strpos($logLine,"watchdog has expired") || strpos($logLine,"ended RF data") || strpos($logLine,"ended network") || strpos($logLine,"transmission lost")) {
 			$lineTokens = explode(", ",$logLine);
 			if (array_key_exists(2,$lineTokens)) {
 				$duration = strtok($lineTokens[2], " ");


### PR DESCRIPTION
Fix a bug while parsing log lines from locally heard RF tranmissions.