### PR TITLE
Fix constant errors

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -83,7 +83,7 @@ include "include/tools.php";
       <h2>YSFGateway-Configuration</h2>
       <div class="input-group">
         <span class="input-group-addon" id="ENABLEYSFGATEWAY" style="width: 300px">Enable YSFGateway</span>
-        <div class="panel-body"><input type="checkbox" name="ENABLEYSFGATEWAY" <?php if (constant("ENABLEYSFGATEWAY")) echo "checked" ?>></div>
+        <div class="panel-body"><input type="checkbox" name="ENABLEYSFGATEWAY" <?php if (defined("ENABLEYSFGATEWAY")) echo "checked" ?>></div>
       </div>
       <div class="input-group">
         <span class="input-group-addon" id="YSFGATEWAYLOGPATH" style="width: 300px">Path to YSFGateway-logfile</span>
@@ -211,7 +211,7 @@ get_tz_options(constant("TIMEZONE"), "Timezone", '');
       </div>
       <div class="input-group">
         <span class="input-group-addon" id="ENABLENETWORKSWITCHING" style="width: 300px">Enable Network-Switching-Function</span>
-        <div class="panel-body"><input type="checkbox" name="ENABLENETWORKSWITCHING" <?php if (constant("ENABLENETWORKSWITCHING")) echo "checked" ?>></div>
+        <div class="panel-body"><input type="checkbox" name="ENABLENETWORKSWITCHING" <?php if (defined("ENABLENETWORKSWITCHING")) echo "checked" ?>></div>
       </div>
       <div class="input-group">
         <span class="input-group-addon" id="SWITCHNETWORKUSER" style="width: 300px">Username for switching networks:</span>


### PR DESCRIPTION
Fixes errors like these:

```
2017-01-10 20:29:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Warning:  constant(): Couldn't find constant ENABLEYSFGATEWAY in /var/www/setup.php on line 86
2017-01-10 20:29:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Warning:  constant(): Couldn't find constant ENABLENETWORKSWITCHING in /var/www/setup.php on line 214
```