### PR TITLE
Use monospaced font for tables

### DIFF
--- a/css/monospacetables.css
+++ b/css/monospacetables.css
@@ -1,0 +1,14 @@
+.localTx {
+   font-family: monospace;
+   font-size: 14px;
+}
+
+.lastHeard {
+   font-family: monospace;
+   font-size: 14px;
+}
+
+.curTx {
+   font-family: monospace;
+   font-size: 14px;
+}

--- a/include/functions.php
+++ b/include/functions.php
@@ -375,6 +375,7 @@ function getHeardList($logLines, $onlyLast) {
       
       
       $target = substr($logLine, $topos + 3);
+      $target = preg_replace('/\s/', '&nbsp;', $target);
       $source = "RF";
       if (strpos($logLine,"network") > 0 ) {
          $source = "Net";

--- a/include/lh_ajax.php
+++ b/include/lh_ajax.php
@@ -6,7 +6,7 @@ $totalLH = count($lastHeard);
   <div class="panel-heading">Last Heard List of today's <?php echo $totalLH; ?> callsigns.</div>
   <!-- Tabelle -->
   <div class="table-responsive">
-  <table id="lastHeard" class="table table-condensed table-striped table-hover">
+  <table id="lastHeard" class="table lastHeard table-condensed table-striped table-hover">
         <thead>
             <tr>
                 <th>Time (<?php echo TIMEZONE;?>)</th>

--- a/include/localtx_ajax.php
+++ b/include/localtx_ajax.php
@@ -6,7 +6,7 @@ $totalLH = count($lastHeard);
   <div class="panel-heading">Today's local transmissions</div>
   <!-- Tabelle -->
   <div class="table-responsive">
-<table id="localTx" class="table table-condensed table-striped table-hover">
+  <table id="localTx" class="table localTx table-condensed table-striped table-hover">
         <thead>
             <tr>
       <th>Time (<?php echo TIMEZONE;?>)</th>

--- a/include/txinfo.php
+++ b/include/txinfo.php
@@ -3,7 +3,7 @@
   <div class="panel-heading">Currently TXing</div>
   <!-- Tabelle -->
   <div class="table-responsive">
-  <table id="currtx" class="table table-condensed table-striped table-hover">
+  <table id="currtx" class="table curTx table-condensed table-striped table-hover">
    <thead>
     <tr>
       <th>Time (<?php echo TIMEZONE;?>)</th>

--- a/index.php
+++ b/index.php
@@ -23,6 +23,8 @@ include "version.php";
      <meta name="viewport" content="width=device-width, initial-scale=0.6,maximum-scale=1, user-scalable=yes">
     <!-- CSS for tooltip display -->
     <link rel="stylesheet" href="css/tooltip.css">
+    <!-- CSS for monospaced fonts in tables -->
+    <link rel="stylesheet" href="css/monospacetables.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.3/jquery.min.js"></script>
     <!-- Das neueste kompilierte und minimierte CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">


### PR DESCRIPTION
This is to address issue #80 
I replaced the fonts in the table with a monospaced one to align the callsigns. Additionally leading whitespace was converted to "&nbsp;"s in order to keep the whitespace and prevent Webserver/Webbroser from cutting them.