### PR TITLE
Strip SSIDs etc. for QRZ and name lookups

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -443,11 +443,13 @@ function getLastHeard($logLines, $onlyLast) {
    foreach ($heardList as $listElem) {
       if ( ($listElem[1] == "D-Star") || ($listElem[1] == "YSF") || ($listElem[1] == "P25") || (startsWith($listElem[1], "DMR")) ) {
          if(!(array_search($listElem[2]."#".$listElem[1].$listElem[4], $heardCalls) > -1)) {
+            // Generate a canonicalized call for QRZ and name lookups
+            $call_canon = preg_replace('/\s+\w$/', '', $listElem[2]);
             array_push($heardCalls, $listElem[2]."#".$listElem[1].$listElem[4]);
             if (defined("ENABLEXTDLOOKUP")) {
                if ($listElem[2] !== "??????????") {
                   //$listElem[3] = "Dummy"; //Should speed up this function - time-issue!
-                  $listElem[3] = getName($listElem[2]); //Should speed up this function - time-issue!
+                  $listElem[3] = getName($call_canon); //Should speed up this function - time-issue!
                } else {
                   $listElem[3] = "---";
                }
@@ -455,9 +457,9 @@ function getLastHeard($logLines, $onlyLast) {
             if ($listElem[2] !== "??????????") {
                if (!is_numeric($listElem[2])) {
                   if (defined("SHOWQRZ")) {
-                     $listElem[2] = "<a target=\"_new\" href=\"https://qrz.com/db/$listElem[2]\">".str_replace("0","&Oslash;",$listElem[2])."</a>";
+                     $listElem[2] = "<a target=\"_new\" href=\"https://qrz.com/db/$call_canon\">".str_replace("0","&Oslash;",$listElem[2])."</a>";
                   } else {
-                     $listElem[2] = "<a target=\"_new\" href=\"http://dmr.darc.de/dmr-userreg.php?callsign=$listElem[2]\">".$listElem[2]."</a>";
+                     $listElem[2] = "<a target=\"_new\" href=\"http://dmr.darc.de/dmr-userreg.php?callsign=$call_canon\">".$listElem[2]."</a>";
                   }
                } else {
                   $listElem[2] = "<a target=\"_new\" href=\"http://dmr.darc.de/dmr-userreg.php?usrid=$listElem[2]\">".$listElem[2]."</a>";


### PR DESCRIPTION
People using SSIDs in their D-Star callsign cause the dashboard to generate invalid links to QRZ and the name lookup fails because the DMRIDs.dat contains canonical callsigns only. 

![screenshot from 2017-01-18 11-02-31](https://cloud.githubusercontent.com/assets/7112907/22059636/0d2e9a46-dd6e-11e6-9c84-00160faacece.png)

In this case its @ernix66 for example.