### PR TITLE
Workaround to fix #55

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -196,7 +196,7 @@ function getMMDVMLog() {
 function getShortMMDVMLog() {
    // Open Logfile and copy loglines into LogLines-Array()
    $logPath = MMDVMLOGPATH."/".MMDVMLOGPREFIX."-".date("Y-m-d").".log";
-   $logLines = explode("\n", `egrep -h "from|end|watchdog|lost|Alias|0000" $logPath | tail -20`);
+   $logLines = explode("\n", `egrep  -v "data header" -h "from|end|watchdog|lost|Alias|0000" $logPath | tail -20`);
 
    return $logLines;
 }


### PR DESCRIPTION
With this exclusion from short logs, it fixes #55.

It's a solution, since it's not a bug from MMDVMHost, but a parse situation from the logs.