### PR TITLE
Fix error with egrep

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -196,7 +196,7 @@ function getMMDVMLog() {
 function getShortMMDVMLog() {
    // Open Logfile and copy loglines into LogLines-Array()
    $logPath = MMDVMLOGPATH."/".MMDVMLOGPREFIX."-".date("Y-m-d").".log";
-   $logLines = explode("\n", `egrep  -v "data header" -h "from|end|watchdog|lost|Alias|0000" $logPath | tail -20`);
+   $logLines = explode("\n", `egrep -h "from|end|watchdog|lost|Alias|0000" $logPath | grep -v "data header" | tail -20`);
 
    return $logLines;
 }


### PR DESCRIPTION
Fix to one of my lasts PR that it give and error on syslog:

Mar  9 01:18:57 CT2JAY-MMDVM lighttpd[8667]: grep: from|end|watchdog|lost|Alias|0000: No such file or directory

Fixing egrep command
- Two _**and**_ expressions with grep you need two invocations 
- No need also to use egrep again, grep it's ok