### PR TITLE
Fix database compatibility with DMR-MARC and BrandMeister network

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -805,13 +805,13 @@ function getName($callsign) {
          $callsign = substr($callsign,0,strpos($callsign,"-"));
       }
       $delimiter =" ";
-      exec("egrep -m1 '".$callsign.$delimiter."' ".DMRIDDATPATH, $output);
-      if (count($output) == 0) {
-         $delimiter = "\t";
-         exec("egrep -m1 '".$callsign.$delimiter."' ".DMRIDDATPATH, $output);
-      }
+      exec("sed -e 's/[[:space:]]\+/ /g' ".DMRIDDATPATH ." | grep -m1 '".$callsign.$delimiter."'" , $output);
+//      if (count($output) == 0) {
+//         $delimiter = "\t";
+//         exec("egrep -m1 '".$callsign.$delimiter."' ".DMRIDDATPATH, $output);
+//      }
       if (count($output) !== 0) {
-         $name = substr($output[0], strpos($output[0],$delimiter)+1);
+         $name = preg_replace('/[\x00-\x1F\x7F-\xA0\xAD]/u', '', substr($output[0], strpos($output[0],$delimiter)+1));
          $name = substr($name, strpos($name,$delimiter)+1);
 
          $fp = fopen($TMP_CALL_NAME .'.TMP', 'a');


### PR DESCRIPTION
Database format get from scripts from DMR-MARC and BrandMeister network are a little different.

As now, we can use one (DMRIDUpdate.sh) or other (DMRIDUpdateBM.sh)

Please see https://github.com/g4klx/MMDVMHost/pull/276

With this fix we can free chose the database to use.