### PR TITLE
Check if .git dir exists before accessing it

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -851,7 +851,11 @@ function decodeAlias($logLine) {
 
 
 function getGitVersion(){
-	exec("git rev-parse HEAD", $output);
-	return 'GitID #<a href="https://github.com/dg9vh/MMDVMHost-Dashboard/commit/'.substr($output[0],0,7).'">'.substr($output[0],0,7).'</a>';
+	if (file_exists(".git")) {
+		exec("git rev-parse HEAD", $output);
+		return 'GitID #<a href="https://github.com/dg9vh/MMDVMHost-Dashboard/commit/'.substr($output[0],0,7).'">'.substr($output[0],0,7).'</a>';
+	} else {
+		return 'GitID unknown';
+	}
 }
 ?>


### PR DESCRIPTION
Prevent errors in the web server's log if .git information is not available.