### PR TITLE
Show DMR-ID

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -155,6 +155,10 @@ function getCallsign($mmdvmconfigs) {
    return getConfigItem("General", "Callsign", $mmdvmconfigs);
 }
 
+function getDMRId ($mmdvmconfigs) {
+   // returns DMRId from MMDVM-Config
+   return getConfigItem("DMR", "Id", $mmdvmconfigs);
+}
 function getConfigItem($section, $key, $configs) {
    // retrieves the corresponding config-entry within a [section]
    $sectionpos = array_search("[" . $section . "]", $configs) + 1;

--- a/index.php
+++ b/index.php
@@ -61,7 +61,8 @@ include "version.php";
   } else {
    echo " "._("Hotspot");
   }
-  ?>:</small>  <?php echo getCallsign($mmdvmconfigs) ?></h1>
+  ?>:</small>  <?php echo getCallsign($mmdvmconfigs) ?><br>
+  <small>DMR-Id: <?php echo getDMRId($mmdvmconfigs) ?></small></h1><hr>
   <h4>MMDVMHost by G4KLX Version: <?php echo getMMDVMHostVersion() ?><br>Firmware: <?php echo getFirmwareVersion();
   if (defined("ENABLEDMRGATEWAY")) {
 ?>


### PR DESCRIPTION
Shows DMR-ID under the Callsig, to see which ID is Used in the actual config.
Added a line between Callsign and ID Header and Host and Gateway Version.