### PR TITLE
Update getActualLink in functions.php

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -781,7 +781,27 @@ function getActualLink($logLines, $mode) {
                   return $to;
                }
             }
-         } else {
+         
+		if ( ($to == "") && file_exists('/tmp/YSFState.txt')) { // reflector is in yesterday's log 
+			$logPath2    = YSFGATEWAYLOGPATH."/".YSFGATEWAYLOGPREFIX."-".date('Y-m-d',strtotime(date('Y-m-d').' -1 day')).".log"; //open yesterday's log
+			$logLines2   = explode("\n", `egrep -h "Linked to" $logPath2`);
+			$to = "";
+			foreach($logLines2 as $logLine) {
+				  if ($logLine!=='') {
+					$to = substr($logLine, 37, 16);
+					if ($to == "MMDVM" )
+						continue;
+				  }
+				}
+			if ($to !== "") {
+				  $fp = fopen('/tmp/YSFState.txt', 'w');
+				  fwrite($fp, $to);
+				  fclose($fp);
+				  return $to;
+			   }
+		}
+		 
+	 } else {
          	return _("YSFGateway not running");
          }
          if (file_exists('/tmp/YSFState.txt')) {


### PR DESCRIPTION
Fixed the following bug:
if the YSF log doesn't cointain "Liked to", but '/tmp/YSFState.txt' exists, the actual reflector is contained in the log of day before.
This could happen if a very long inactivity timeout is set in MMDVM.ini. 
In this case, the MMDVM could remain linked to the reflector from one day to the next.
The real case that happened to me is the following:
- A user connects to a new reflector before midnight;
- In the meantime, nobody opens the dashboard, sto '/tmp/YSFState.txt' is not updated to the last reflector;
- New day begins, so a new YSF log file is created, without information of the actual reflector;
- Dashboards in this case shows the old reflector (of the day before), not the actual